### PR TITLE
worker: accept French decimal format

### DIFF
--- a/geotaxi/worker.py
+++ b/geotaxi/worker.py
@@ -97,7 +97,13 @@ class Worker:
 
     @staticmethod
     def validate_convert_coordinates(data):
-        data['lon'], data['lat'] = float(data['lon']), float(data['lat'])
+        lon, lat = str(data['lon']), str(data['lat'])
+        # Accept the French decimal format
+        lon, lat = lon.replace(',', '.'), lat.replace(',', '.')
+        try:
+            data['lon'], data['lat'] = float(lon), float(lat)
+        except ValueError:
+            return False
         return -90 <= data['lat'] <= 90 and -180 <= data['lon'] <= 180
 
     def parse_message(self, b_message, from_addr):

--- a/tests/test_geotaxi.py
+++ b/tests/test_geotaxi.py
@@ -183,3 +183,33 @@ class TestWorker:
 
         assert b'ips:%s' % payload['operator'].encode('utf8') in redis.keys()
         assert fromaddr[0].encode('utf8') in redis.smembers(b'ips:%s' % payload['operator'].encode('utf8'))
+
+    def test_validate_convert_coordinates(self):
+        worker = Worker(None)
+
+        data = {
+            'lon': 2.346303339766483,
+            'lat': 48.865546846846846,
+        }
+        assert worker.validate_convert_coordinates(data)
+        assert data == {
+            'lon': 2.346303339766483,
+            'lat': 48.865546846846846,
+        }
+
+        # French decimal format
+        data = {
+            'lon': "2,346303339766483",
+            'lat': "48,865546846846846",
+        }
+        assert worker.validate_convert_coordinates(data)
+        assert data == {
+            'lon': 2.346303339766483,
+            'lat': 48.865546846846846,
+        }
+
+        data = {
+            'lon': "2,346 303 339 766 483",
+            'lat': "48,865 546 846 846 846",
+        }
+        assert not worker.validate_convert_coordinates(data)


### PR DESCRIPTION
This would trigger errors in Sentry. Easier to convert them than track
down and push the operator doing that to edit their code.

We would rather convince them to use the new endpoint.